### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,9 +20,11 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm ci && npm run build
+      - run: npm ci
+      - run: npm run build
       - run: |
-          if [ -f dist/index.html ]; then cp dist/index.html dist/404.html; fi
+          # SPA fallback para rutas (React Router)
+          [ -f dist/index.html ] && cp dist/index.html dist/404.html || true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,31 @@
-node_modules
+# Node
+node_modules/
+dist/
+build/
+*.log
+
+# SO/editores
 .DS_Store
-dist
-.idea
-.vscode
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+.vscode/
+.idea/
+
+# Binarios comunes (NO subir)
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.ico
+*.icns
+*.mp4
+*.mov
+*.pdf
+*.zip
+*.gz
+*.tar
+*.7z
+*.exe
+*.dmg
+
+# Permitimos SVG (texto)
+!*.svg

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Presupuesto LC</title>
+    <link
+      rel="icon"
+      href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">👓</text></svg>'
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,9 +1,9 @@
 {
-  "name": "Presupuesto LC Offline",
-  "short_name": "Presupuesto LC",
-  "start_url": ".",
+  "name": "Presupuesto LC",
+  "short_name": "LC",
+  "start_url": "/Presupuesto-LC-definifiva/",
+  "scope": "/Presupuesto-LC-definifiva/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#2563eb",
-  "icons": []
+  "theme_color": "#0f172a"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,9 @@
 const CACHE_NAME = 'presupuesto-lc-cache-v1';
+const BASE_URL = new URL('./', self.location.href).pathname;
 const OFFLINE_ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest'
+  BASE_URL,
+  `${BASE_URL}index.html`,
+  `${BASE_URL}manifest.webmanifest`,
 ];
 
 self.addEventListener('install', (event) => {
@@ -44,7 +45,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, cloned));
           return response;
         })
-        .catch(() => caches.match('/index.html'));
+        .catch(() => caches.match(`${BASE_URL}index.html`));
     })
   );
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const basePath = process.env.VITE_BASE_PATH ?? '/';
-
 export default defineConfig({
   plugins: [react()],
-  base: basePath,
+  base: '/Presupuesto-LC-definifiva/',
 });


### PR DESCRIPTION
## Summary
- set Vite base path and PWA manifest scope to match the repository slug for GitHub Pages
- add inline SVG favicon and refine the service worker caching paths for the new base URL
- ignore common binary assets and add a GitHub Actions workflow to build and deploy to Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df955a55f88322aca0fb9a1999c76d