### PR TITLE
Configure GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,9 +20,11 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm ci && npm run build
+      - run: npm ci
+      - run: npm run build
       - run: |
-          if [ -f dist/index.html ]; then cp dist/index.html dist/404.html; fi
+          # SPA fallback para rutas (React Router)
+          [ -f dist/index.html ] && cp dist/index.html dist/404.html || true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,31 @@
-node_modules
+# Node
+node_modules/
+dist/
+build/
+*.log
+
+# SO/editores
 .DS_Store
-dist
-.idea
-.vscode
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+.vscode/
+.idea/
+
+# Binarios comunes (NO subir)
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.ico
+*.icns
+*.mp4
+*.mov
+*.pdf
+*.zip
+*.gz
+*.tar
+*.7z
+*.exe
+*.dmg
+
+# Permitimos SVG (texto)
+!*.svg

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">👓</text></svg>' />
+    <link rel="manifest" href="manifest.webmanifest" />
     <title>Presupuesto LC</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,9 +1,9 @@
 {
-  "name": "Presupuesto LC Offline",
-  "short_name": "Presupuesto LC",
-  "start_url": ".",
+  "name": "Presupuesto LC",
+  "short_name": "LC",
+  "start_url": "/Presupuesto-LC-definifiva/",
+  "scope": "/Presupuesto-LC-definifiva/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#2563eb",
-  "icons": []
+  "theme_color": "#2563eb"
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,7 @@
-const CACHE_NAME = 'presupuesto-lc-cache-v1';
-const OFFLINE_ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest'
-];
+const CACHE_NAME = 'presupuesto-lc-cache-v2';
+const BASE_PATH = new URL(self.registration.scope).pathname;
+const OFFLINE_URL = `${BASE_PATH}index.html`;
+const OFFLINE_ASSETS = [OFFLINE_URL, `${BASE_PATH}manifest.webmanifest`];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -19,18 +17,23 @@ self.addEventListener('activate', (event) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== CACHE_NAME)
-            .map((key) => caches.delete(key))
-        )
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
       )
       .then(() => self.clients.claim())
   );
 });
 
 self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') return;
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    );
+    return;
+  }
 
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
@@ -44,7 +47,7 @@ self.addEventListener('fetch', (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, cloned));
           return response;
         })
-        .catch(() => caches.match('/index.html'));
+        .catch(() => caches.match(OFFLINE_URL));
     })
   );
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-const basePath = process.env.VITE_BASE_PATH ?? '/';
-
 export default defineConfig({
   plugins: [react()],
-  base: basePath,
+  base: '/Presupuesto-LC-definifiva/',
 });


### PR DESCRIPTION
## Summary
- set the Vite base path for GitHub Pages and add an inline SVG favicon plus manifest updates
- update the service worker to serve the app from the repository sub-path without cached binaries
- add a GitHub Pages deployment workflow and expand the .gitignore to filter binary assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df955a55f88322aca0fb9a1999c76d